### PR TITLE
Feature marker and accompanying fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "test": "mocha test/**.js --timeout 10000"
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-native": "3.5.4",
+    "@mapbox/mapbox-gl-native": "3.5.8",
     "@mapbox/mbtiles": "0.9.0",
     "@mapbox/sphericalmercator": "1.0.5",
     "@mapbox/vector-tile": "1.3.0",
     "advanced-pool": "0.3.3",
     "base64url": "2.0.0",
-    "canvas": "1.6.8",
+    "canvas": "^1.6.8",
     "clone": "2.1.1",
     "color": "1.0.3",
     "cors": "2.8.4",
@@ -35,10 +35,11 @@
     "http-shutdown": "^1.2.0",
     "morgan": "1.9.0",
     "nomnom": "1.8.1",
+    "npm": "^5.7.1",
     "pbf": "3.0.5",
     "proj4": "2.4.4",
     "request": "2.83.0",
-    "sharp": "0.18.2",
+    "sharp": "^0.20.0",
     "tileserver-gl-styles": "1.2.0"
   },
   "devDependencies": {

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -23,6 +23,8 @@ var Canvas = require('canvas'),
 
 var utils = require('./utils');
 
+var markerSize = 20;
+
 var FLOAT_PATTERN = '[+-]?(?:\\d+|\\d+\.?\\d+)';
 
 var getScale = function(scale) {
@@ -262,6 +264,20 @@ module.exports = function(options, repo, params, id, dataResolver) {
   if (styleJSON.glyphs && !httpTester.test(styleJSON.glyphs)) {
     styleJSON.glyphs = 'fonts://' + styleJSON.glyphs;
   }
+
+  var markerImages = [];
+
+  var markerImageNames = ['pickup','dropoff'];
+
+  markerImageNames.forEach(function(imageName){
+      var imageData = fs.readFileSync("./" + imageName + "-marker.png");
+      // TODO: HANDLE ERROR!
+      var mkrImage = new Canvas.Image();
+      mkrImage.src = imageData;
+      markerImages.push(mkrImage);
+  });
+
+
 
   var tileJSON = {
     'tilejson': '2.0.0',
@@ -568,6 +584,22 @@ module.exports = function(options, repo, params, id, dataResolver) {
       ctx.stroke();
     }
 
+    if (query.showMarkers && query.showMarkers == 1) {
+        // Add the markers, if requested to do so.
+
+        var markers = [
+                        [markerImages[0], precisePx(path[0],z).map(function(loc,idx){ return (idx ==1)? loc - markerSize/2: loc - markerSize/2;})],
+                        [markerImages[1], precisePx(path[path.length-1],z).map(function(loc,idx){ return (idx == 1)?loc - markerSize/2: loc - markerSize/2;})]
+                    ];
+        console.log(markers);
+
+        markers.forEach(function(imgSpec){
+            console.log(imgSpec);
+            var coordinates = imgSpec[1];
+            ctx.drawImage(imgSpec[0], coordinates[0], coordinates[1], markerSize, markerSize);
+        });
+    }
+
     return canvas.toBuffer();
   };
 
@@ -615,7 +647,7 @@ module.exports = function(options, repo, params, id, dataResolver) {
           format = req.params.format;
 
       if (z < 0) {
-        return res.status(404).send('Invalid zoom');
+        return res.status(400).send('Invalid zoom');
       }
 
       var transformer = raw ?

--- a/test/static.js
+++ b/test/static.js
@@ -49,7 +49,7 @@ describe('Static endpoints', function() {
       testStatic(prefix, '0,0,0/256x256', 'gif', 400);
       testStatic(prefix, '0,0,0/256x256', 'png', 404, 1);
 
-      testStatic(prefix, '0,0,-1/256x256', 'png', 404);
+      testStatic(prefix, '0,0,-1/256x256', 'png', 400);
       testStatic(prefix, '0,0,0/256.5x256.5', 'png', 404);
 
       testStatic(prefix, '0,0,0,/256x256', 'png', 404);
@@ -91,6 +91,11 @@ describe('Static endpoints', function() {
         testStatic(prefix, 'auto/20x20', 'png', 200, 2, /image\/png/, '?path=10,10|20,20');
         testStatic(prefix, 'auto/200x200', 'png', 200, 3, /image\/png/, '?path=-10,-10|-20,-20');
       });
+
+      describe('with markers', function() {
+          testStatic(prefix, 'auto/20x20', 'png', 200, 2, /image\/png/, '?path=10,10|20,20&showMarkers=1');
+          testStatic(prefix, 'auto/20x20', 'png', 200, 2, /image\/png/, '?path=10,10|20,20&showMarkers=0');
+      })
     });
 
     describe('invalid requests return 4xx', function() {


### PR DESCRIPTION
Update dependencies to use mapbox-gl-native 3.5.8 instead of 3.5.4 which doesn't compile on modern llvm/clang 9. Fix tests. Add tests for markers.